### PR TITLE
Add MarketAnalysis controller unit tests

### DIFF
--- a/RealEstateManagement.API.Tests/MarketAnalysisControllerTests.cs
+++ b/RealEstateManagement.API.Tests/MarketAnalysisControllerTests.cs
@@ -1,0 +1,42 @@
+using Microsoft.AspNetCore.Mvc;
+using RealEstateManagement.API.Controllers;
+using RealEstateManagement.API.Models;
+using Xunit;
+
+namespace RealEstateManagement.API.Tests;
+
+public class MarketAnalysisControllerTests
+{
+    [Fact]
+    public void Calculate_ValidInputs_ReturnsOkWithExpectedCapRate()
+    {
+        // Arrange
+        var controller = new MarketAnalysisController();
+        decimal purchasePrice = 100000m;
+        decimal monthlyRent = 1000m;
+        decimal expectedCapRate = (monthlyRent * 12) / purchasePrice;
+
+        // Act
+        ActionResult<MarketAnalysisResult> actionResult = controller.Calculate(purchasePrice, monthlyRent);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(actionResult.Result);
+        var resultValue = Assert.IsType<MarketAnalysisResult>(okResult.Value);
+        Assert.Equal(expectedCapRate, resultValue.CapRate);
+    }
+
+    [Fact]
+    public void Calculate_NegativeMonthlyRent_ReturnsBadRequest()
+    {
+        // Arrange
+        var controller = new MarketAnalysisController();
+        decimal purchasePrice = 100000m;
+        decimal monthlyRent = -500m;
+
+        // Act
+        ActionResult<MarketAnalysisResult> actionResult = controller.Calculate(purchasePrice, monthlyRent);
+
+        // Assert
+        Assert.IsType<BadRequestObjectResult>(actionResult.Result);
+    }
+}

--- a/RealEstateManagement.API.Tests/RealEstateManagement.API.Tests.csproj
+++ b/RealEstateManagement.API.Tests/RealEstateManagement.API.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\RealEstateManagement.API\RealEstateManagement.API.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add xUnit test project
- cover cap rate calculation and negative rent validation in MarketAnalysisController

## Testing
- `dotnet test RealEstateManagement.API.Tests/RealEstateManagement.API.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a13228c1dc832fbffdf0fd3b9748b3