### PR TITLE
docs: clarify cap-rate summary

### DIFF
--- a/RealEstateManagement.API/Controllers/MarketAnalysisController.cs
+++ b/RealEstateManagement.API/Controllers/MarketAnalysisController.cs
@@ -12,9 +12,8 @@ namespace RealEstateManagement.API.Controllers;
 public class MarketAnalysisController : ControllerBase
 {
     /// <summary>
-    /// Calculate a simple cap rate and cash‑on‑cash return for a property.  Supply the
-    /// purchase price and expected monthly rent.  All values are placeholders and do not
-    /// constitute financial advice.
+    /// Calculate a simple cap rate for a property.  Supply the purchase price and expected
+    /// monthly rent.  All values are placeholders and do not constitute financial advice.
     /// </summary>
     /// <param name="purchasePrice">Purchase price of the property.</param>
     /// <param name="monthlyRent">Expected monthly rent.</param>


### PR DESCRIPTION
## Summary
- limit `Calculate` endpoint documentation to cap-rate calculation only

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a132208aa8832f98bf9d9f6a7c4e03