### PR TITLE
feat: expand property controller with update and delete

### DIFF
--- a/RealEstateManagement.API/Controllers/PropertyController.cs
+++ b/RealEstateManagement.API/Controllers/PropertyController.cs
@@ -70,4 +70,62 @@ public class PropertyController : ControllerBase
 
         return CreatedAtAction(nameof(GetById), new { id = property.Id }, property);
     }
+
+    /// <summary>
+    /// Update an existing property.
+    /// </summary>
+    /// <param name="id">The id of the property to update.</param>
+    /// <param name="property">The updated property details.</param>
+    [HttpPut("{id}")]
+    public async Task<IActionResult> Update(int id, [FromBody] Property property)
+    {
+        if (property == null)
+        {
+            return BadRequest("Property object is null");
+        }
+
+        if (id != property.Id)
+        {
+            return BadRequest("Property ID mismatch");
+        }
+
+        if (string.IsNullOrWhiteSpace(property.Address))
+        {
+            return BadRequest("Address is required");
+        }
+
+        var existingProperty = await _context.Properties.FindAsync(id);
+        if (existingProperty == null)
+        {
+            return NotFound();
+        }
+
+        existingProperty.Address = property.Address;
+        existingProperty.Bedrooms = property.Bedrooms;
+        existingProperty.MonthlyRent = property.MonthlyRent;
+        existingProperty.PurchasePrice = property.PurchasePrice;
+
+        await _context.SaveChangesAsync();
+
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Remove a property from the portfolio.
+    /// </summary>
+    /// <param name="id">The id of the property to delete.</param>
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(int id)
+    {
+        var property = await _context.Properties.FindAsync(id);
+        if (property == null)
+        {
+            return NotFound();
+        }
+
+        _context.Properties.Remove(property);
+        await _context.SaveChangesAsync();
+
+        return NoContent();
+    }
 }


### PR DESCRIPTION
## Summary
- add update endpoint to modify property records
- add delete endpoint to remove property entries
- validate inputs and return appropriate error codes

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update && apt-get install -y dotnet-sdk-8.0` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a138b643b8832fbd23f6361da20b7a