### PR TITLE
Add unit tests for controllers

### DIFF
--- a/RealEstateManagement.API.Tests/AcquisitionControllerTests.cs
+++ b/RealEstateManagement.API.Tests/AcquisitionControllerTests.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Mvc;
+using RealEstateManagement.API.Controllers;
+using RealEstateManagement.API.Models;
+using System.Collections.Generic;
+using Xunit;
+
+namespace RealEstateManagement.API.Tests;
+
+public class AcquisitionControllerTests
+{
+    [Fact]
+    public void GetAll_ReturnsOkWithEmptyList()
+    {
+        // Arrange
+        var controller = new AcquisitionController();
+
+        // Act
+        ActionResult<IEnumerable<InvestmentOpportunity>> result = controller.GetAll();
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var opportunities = Assert.IsType<List<InvestmentOpportunity>>(okResult.Value);
+        Assert.Empty(opportunities);
+    }
+}

--- a/RealEstateManagement.API.Tests/PropertyControllerTests.cs
+++ b/RealEstateManagement.API.Tests/PropertyControllerTests.cs
@@ -1,0 +1,64 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using RealEstateManagement.API.Controllers;
+using RealEstateManagement.API.Data;
+using RealEstateManagement.API.Models;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RealEstateManagement.API.Tests;
+
+public class PropertyControllerTests
+{
+    private static RealEstateContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<RealEstateContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new RealEstateContext(options);
+    }
+
+    [Fact]
+    public async Task GetById_ExistingProperty_ReturnsProperty()
+    {
+        using var context = CreateContext();
+        var property = new Property { Address = "123 Main St", Bedrooms = 3, MonthlyRent = 1000m, PurchasePrice = 100000m };
+        context.Properties.Add(property);
+        await context.SaveChangesAsync();
+        var controller = new PropertyController(context);
+
+        var result = await controller.GetById(property.Id);
+
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var returned = Assert.IsType<Property>(okResult.Value);
+        Assert.Equal(property.Address, returned.Address);
+    }
+
+    [Fact]
+    public async Task GetById_UnknownProperty_ReturnsNotFound()
+    {
+        using var context = CreateContext();
+        var controller = new PropertyController(context);
+
+        var result = await controller.GetById(1);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task Create_ValidProperty_ReturnsCreated()
+    {
+        using var context = CreateContext();
+        var controller = new PropertyController(context);
+        var property = new Property { Address = "456 Elm St", Bedrooms = 2, MonthlyRent = 800m, PurchasePrice = 75000m };
+
+        var result = await controller.Create(property);
+
+        var created = Assert.IsType<CreatedAtActionResult>(result.Result);
+        var createdProperty = Assert.IsType<Property>(created.Value);
+        Assert.Equal(property.Address, createdProperty.Address);
+        Assert.Equal(1, await context.Properties.CountAsync());
+    }
+}

--- a/RealEstateManagement.API.Tests/RealEstateManagement.API.Tests.csproj
+++ b/RealEstateManagement.API.Tests/RealEstateManagement.API.Tests.csproj
@@ -7,6 +7,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RealEstateManagement.API\RealEstateManagement.API.csproj" />

--- a/RealEstateManagement.API.Tests/TenantControllerTests.cs
+++ b/RealEstateManagement.API.Tests/TenantControllerTests.cs
@@ -1,0 +1,68 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using RealEstateManagement.API.Controllers;
+using RealEstateManagement.API.Data;
+using RealEstateManagement.API.Models;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RealEstateManagement.API.Tests;
+
+public class TenantControllerTests
+{
+    private static RealEstateContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<RealEstateContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new RealEstateContext(options);
+    }
+
+    [Fact]
+    public async Task GetAll_ReturnsTenants()
+    {
+        using var context = CreateContext();
+        context.Tenants.Add(new Tenant
+        {
+            Name = "John Doe",
+            Email = "john@example.com",
+            PropertyId = 1,
+            LeaseStart = DateTime.UtcNow,
+            LeaseEnd = DateTime.UtcNow.AddMonths(12),
+            MonthlyRent = 1200m
+        });
+        await context.SaveChangesAsync();
+        var controller = new TenantController(context);
+
+        var result = await controller.GetAll();
+
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var tenants = Assert.IsType<List<Tenant>>(okResult.Value);
+        Assert.Single(tenants);
+    }
+
+    [Fact]
+    public async Task Create_ValidTenant_ReturnsCreated()
+    {
+        using var context = CreateContext();
+        var controller = new TenantController(context);
+        var tenant = new Tenant
+        {
+            Name = "Jane Smith",
+            Email = "jane@example.com",
+            PropertyId = 1,
+            LeaseStart = DateTime.UtcNow,
+            LeaseEnd = DateTime.UtcNow.AddMonths(6),
+            MonthlyRent = 1000m
+        };
+
+        var result = await controller.Create(tenant);
+
+        var created = Assert.IsType<CreatedAtActionResult>(result.Result);
+        var createdTenant = Assert.IsType<Tenant>(created.Value);
+        Assert.Equal(tenant.Name, createdTenant.Name);
+        Assert.Equal(1, await context.Tenants.CountAsync());
+    }
+}


### PR DESCRIPTION
## Summary
- add acquisition controller test verifying empty opportunity list
- add property controller tests using in-memory EF Core context
- add tenant controller tests for retrieval and creation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a13b30d798832faa9cc1eb782160d1